### PR TITLE
The issue with the CAGR calculation has been solved

### DIFF
--- a/quantstats/stats.py
+++ b/quantstats/stats.py
@@ -521,7 +521,13 @@ def cagr(returns, rf=0.0, compounded=True, periods=252):
     else:
         total = _np.sum(total, axis=0)
 
-    years = (returns.index[-1] - returns.index[0]).days / periods
+    
+    if periods==252:
+        """ Number of Trading days in single calendar year is 252 and return dataframe having only trading days data """
+        years = len(returns) / periods
+    else:
+        """ When we calculating number days between first and last record means we getting all calendar days then we need to divided by 365 days instead of 252 days """
+        years = (returns.index[-1] - returns.index[0]).days / 365
 
     res = abs(total + 1.0) ** (1.0 / years) - 1
 


### PR DESCRIPTION
The line of code (returns.index[-1] - returns.index[0]).days gives the total number of calendar days between two dates, including weekends and holidays—essentially, it counts all days in the range (e.g., 365 or 366 days per year depending on leap years). To convert this into years, we divide the result by 365.

The expression len(returns) returns the number of trading days in the DataFrame, since the data typically only includes trading days (i.e., it excludes weekends and holidays). To convert trading days into years, we divide by 252, which is the approximate number of trading days in a year.